### PR TITLE
FIX: comptabilité sous-total non-compris

### DIFF
--- a/core/triggers/interface_97_modTarif_TarifWorkflow.class.php
+++ b/core/triggers/interface_97_modTarif_TarifWorkflow.class.php
@@ -158,12 +158,19 @@ class InterfaceTarifWorkflow
 	}
 
 	function _updateTotauxLine(&$object,$qty){
-		//MAJ des totaux de la ligne
-		$object->total_ht  = price2num($object->subprice * $qty * (1 - $object->remise_percent / 100), 'MT');
-		$object->total_tva = price2num(($object->total_ht * (1 + ($object->tva_tx/100))) - $object->total_ht, 'MT');
-		$object->total_ttc = price2num($object->total_ht + $object->total_tva, 'MT');
-		if (method_exists($object, 'update_total')) $object->update_total();
-		elseif (method_exists($object, 'updateTotal')) $object->updateTotal();
+		if(empty($object->array_options) && method_exists($object, 'fetch_optionals')) {
+			$object->fetch_optionals();
+		}
+
+		if(empty($object->array_options['options_subtotal_nc'])) { // Compatibilité sous-total : les lignes non-comprises doivent rester à 0
+
+			//MAJ des totaux de la ligne
+			$object->total_ht  = price2num($object->subprice * $qty * (1 - $object->remise_percent / 100), 'MT');
+			$object->total_tva = price2num(($object->total_ht * (1 + ($object->tva_tx/100))) - $object->total_ht, 'MT');
+			$object->total_ttc = price2num($object->total_ht + $object->total_tva, 'MT');
+			if (method_exists($object, 'update_total')) $object->update_total();
+			elseif (method_exists($object, 'updateTotal')) $object->updateTotal();
+		}
 	}
 
 	function _getObjectParent(&$object){


### PR DESCRIPTION
Tarif recalculait le total de la ligne et de la facture juste après qu'on passe une ligne en "non compris"